### PR TITLE
#61 [epic] : 랜드마크 신청 기능 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,4 +75,7 @@ dependencies {
 
     // Google Play Service OpenSource Licenses
     implementation 'com.google.android.gms:play-services-oss-licenses:17.0.0'
+
+    // Glide
+    implementation 'com.github.bumptech.glide:glide:4.12.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"/>
+
     <application
         android:name=".AlBangApplication"
         android:allowBackup="true"
@@ -39,6 +42,18 @@
 
         <meta-data android:name="com.naver.maps.map.CLIENT_ID"
             android:value="@string/naver_client_id" />
+
+        <provider
+            android:authorities="com.pns.albang"
+            android:name="androidx.core.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths">
+
+            </meta-data>
+        </provider>
 
     </application>
 

--- a/app/src/main/java/com/pns/albang/remote/ApiService.kt
+++ b/app/src/main/java/com/pns/albang/remote/ApiService.kt
@@ -7,12 +7,16 @@ import com.pns.albang.remote.dto.user.SignInRequest
 import com.pns.albang.remote.dto.user.UpdateNicknameRequest
 import com.pns.albang.remote.dto.user.UserResponse
 import com.pns.albang.remote.dto.user.ValidateNicknameResponse
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -59,4 +63,11 @@ interface ApiService {
     suspend fun deleteGuestbook(
         @Path("id") guestbookId: Long
     ) : Response<Void>
+
+    @Multipart
+    @POST("/landmark/application")
+    suspend fun applyLandmark(
+        @Part image: MultipartBody.Part,
+        @Part("body") body: RequestBody
+    ) : Response<LandmarkResponse>
 }

--- a/app/src/main/java/com/pns/albang/remote/dto/landmark/LandmarkApplicationRequest.kt
+++ b/app/src/main/java/com/pns/albang/remote/dto/landmark/LandmarkApplicationRequest.kt
@@ -1,0 +1,15 @@
+package com.pns.albang.remote.dto.landmark
+
+import com.google.gson.annotations.SerializedName
+
+data class LandmarkApplicationRequest(
+
+    @SerializedName("name")
+    val name: String,
+
+    @SerializedName("latitude")
+    val latitude: String,
+
+    @SerializedName("longitude")
+    val longitude: String
+)

--- a/app/src/main/java/com/pns/albang/repository/LandmarkRepository.kt
+++ b/app/src/main/java/com/pns/albang/repository/LandmarkRepository.kt
@@ -1,10 +1,14 @@
 package com.pns.albang.repository
 
 import com.pns.albang.remote.RemoteDataSource
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 
 object LandmarkRepository {
 
     private val remoteApiService = RemoteDataSource.apiService
 
     suspend fun getLandmark() = remoteApiService.getLandmark()
+    suspend fun applyLandmark(image: MultipartBody.Part, body: RequestBody) =
+        remoteApiService.applyLandmark(image, body)
 }

--- a/app/src/main/java/com/pns/albang/view/LandmarkApplicationBottomSheet.kt
+++ b/app/src/main/java/com/pns/albang/view/LandmarkApplicationBottomSheet.kt
@@ -1,0 +1,149 @@
+package com.pns.albang.view
+
+import android.app.Activity.RESULT_OK
+import android.app.Dialog
+import android.content.ContentValues
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.MediaStore
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.activityViewModels
+import com.bumptech.glide.Glide
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.pns.albang.R
+import com.pns.albang.databinding.DialogApplicationLandmarkBinding
+import com.pns.albang.viewmodel.MainViewModel
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class LandmarkApplicationBottomSheet : BottomSheetDialogFragment() {
+
+    private lateinit var binding: DialogApplicationLandmarkBinding
+    private val viewModel: MainViewModel by activityViewModels()
+
+    private val getPictureFromGallery = registerForActivityResult(ActivityResultContracts.GetContent()) {
+        it?.let { uri ->
+            Glide.with(this).load(uri).into(binding.ivImage)
+            imageUri = uri
+        }
+    }
+
+    private val takePicture = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        if (result.resultCode == RESULT_OK) {
+            imageUri.let {
+                Glide.with(this).load(it).into(binding.ivImage)
+            }
+        } else {
+            requireActivity().contentResolver.delete(imageUri, null, null)
+        }
+    }
+
+    private lateinit var imageName: String
+    private lateinit var imageUri: Uri
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        binding = DialogApplicationLandmarkBinding.inflate(inflater, container, false)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.view = this
+        binding.viewModel = viewModel
+
+        return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        return dialog
+    }
+
+    fun onClick(view: View) {
+        when (view.id) {
+            R.id.btn_close -> {
+                dismiss()
+            }
+            R.id.btn_gallery -> {
+                getPictureFromGallery.launch("image/*")
+            }
+            R.id.btn_camera -> {
+                val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
+                    val timeStamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+                    imageName = "$timeStamp.jpg"
+                    imageUri = createImageUri(imageName, "image/jpeg")!!
+                    putExtra(MediaStore.EXTRA_OUTPUT, imageUri)
+                }
+                takePicture.launch(intent)
+            }
+            R.id.btn_application -> {
+                val file = getFilePathFromUri(imageUri)
+                if (file == null) {
+                    viewModel.showDialog("apply failed")
+                } else {
+                    viewModel.applyLandmark(file, binding.etName.text.toString())
+                }
+            }
+        }
+    }
+
+    private fun createImageUri(fileName: String, mimeType: String): Uri? {
+        val contentValue = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.MIME_TYPE, mimeType)
+        }
+        return requireActivity().contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValue)
+    }
+
+    private fun getFilePathFromUri(uri: Uri): File? {
+        val fileName = getFileName(uri)
+        if (!fileName.isNullOrEmpty()) {
+            val copyFile = File("${requireContext().filesDir}${File.separator}$fileName.jpg")
+            copy(uri, copyFile)
+            return copyFile
+        }
+        return null
+    }
+
+    private fun getFileName(uri: Uri): String? {
+        val path = uri.path
+        path?.let {
+            val cut = it.lastIndexOf('/')
+            if (cut != -1) {
+                return it.substring(cut + 1)
+            }
+        }
+        return null
+    }
+
+    private fun copy(uri: Uri, file: File) {
+        try {
+            val inputStream = requireContext().contentResolver.openInputStream(uri)
+            inputStream?.let { ist ->
+                val outputStream = FileOutputStream(file)
+                val buf = ByteArray(1024)
+                var len: Int
+                while (ist.read(buf).also { len = it } > 0) {
+                    outputStream.write(buf, 0, len)
+                }
+                ist.close()
+                outputStream.close()
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
+
+    companion object {
+        const val TAG = "Landmark Application Bottom Sheet Dialog"
+    }
+}

--- a/app/src/main/java/com/pns/albang/view/MainActivity.kt
+++ b/app/src/main/java/com/pns/albang/view/MainActivity.kt
@@ -7,6 +7,7 @@ import android.view.Gravity
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.LocationTrackingMode
@@ -20,7 +21,6 @@ import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.util.FusedLocationSource
 import com.pns.albang.R
 import com.pns.albang.ReviewActivity
-import com.pns.albang.TestActivity
 import com.pns.albang.databinding.ActivityMainBinding
 import com.pns.albang.viewmodel.MainViewModel
 
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var circleOverlay: CircleOverlay
     private val landmarkInfoWindow = InfoWindow()
 
-    private var guestBookIntent = Intent(this, TestActivity::class.java)
+    private lateinit var bottomSheet: LandmarkApplicationBottomSheet
 
     private val onMapReadyCallback = OnMapReadyCallback {
         this.naverMap = it.apply {
@@ -105,10 +105,6 @@ class MainActivity : AppCompatActivity() {
         binding.btnSetting.setOnClickListener {
             startActivity(Intent(this, MyPageActivity::class.java))
         }
-
-        binding.btnBottom.setOnClickListener {
-            startActivity(guestBookIntent)
-        }
     }
 
     private fun setObserver() {
@@ -138,14 +134,19 @@ class MainActivity : AppCompatActivity() {
             val landmark = it.getContentIfNotHandled()
 
             if (landmark == null) {
-                guestBookIntent = Intent(this@MainActivity, TestActivity::class.java)
+                // guestBookIntent = Intent(this@MainActivity, TestActivity::class.java)
 
                 binding.btnBottom.apply {
                     icon = ContextCompat.getDrawable(this@MainActivity, R.drawable.ic_btn_request)
                     text = getString(R.string.btn_request)
+                    setOnClickListener {
+                        viewModel.setLocationForApplication(circleOverlay.center)
+                        bottomSheet = LandmarkApplicationBottomSheet()
+                        bottomSheet.show(supportFragmentManager, LandmarkApplicationBottomSheet.TAG)
+                    }
                 }
             } else {
-                guestBookIntent = Intent(this@MainActivity, ReviewActivity::class.java).apply {
+                val guestBookIntent = Intent(this@MainActivity, ReviewActivity::class.java).apply {
                     putExtra("landmark", landmark.id)
                     putExtra("landmarkImage", landmark.imageName)
                     putExtra("landmarkName", landmark.name)
@@ -154,7 +155,42 @@ class MainActivity : AppCompatActivity() {
                 binding.btnBottom.apply {
                     icon = ContextCompat.getDrawable(this@MainActivity, R.drawable.ic_guestbook)
                     text = getString(R.string.btn_show_guestbook)
+                    setOnClickListener {
+                        startActivity(guestBookIntent)
+                    }
                 }
+            }
+        }
+
+        viewModel.showDialog.observe(this) {
+            it.getContentIfNotHandled()?.let { type ->
+                bottomSheet.dismiss()
+                showDialog(type)
+            }
+        }
+    }
+
+    private fun showDialog(type: String) {
+        when (type) {
+            "apply failed" -> {
+                MaterialAlertDialogBuilder(this)
+                    .setTitle(getString(R.string.apply_fail_title))
+                    .setMessage(getString(R.string.apply_fail_message))
+                    .setPositiveButton(getString(R.string.btn_confirm)) { dialogInterface, _ ->
+                        dialogInterface.dismiss()
+                    }
+                    .setCancelable(false)
+                    .show()
+            }
+            "apply success" -> {
+                MaterialAlertDialogBuilder(this)
+                    .setTitle(getString(R.string.apply_success_title))
+                    .setMessage(getString(R.string.apply_success_message))
+                    .setPositiveButton(getString(R.string.btn_confirm)) { dialogInterface, _ ->
+                        dialogInterface.dismiss()
+                    }
+                    .setCancelable(false)
+                    .show()
             }
         }
     }

--- a/app/src/main/res/drawable/btn_close.xml
+++ b/app/src/main/res/drawable/btn_close.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/colorText">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_image_holder.xml
+++ b/app/src/main/res/drawable/ic_image_holder.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,5v14L5,19L5,5h14m0,-2L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM14.14,11.86l-3,3.87L9,13.14 6,17h12l-3.86,-5.14z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_application_landmark.xml
+++ b/app/src/main/res/layout/dialog_application_landmark.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="view"
+            type="com.pns.albang.view.LandmarkApplicationBottomSheet" />
+
+        <variable
+            name="viewModel"
+            type="com.pns.albang.viewmodel.MainViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/spacing_normal">
+
+        <ImageView
+            android:id="@+id/btn_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/btn_close"
+            android:padding="@dimen/spacing_small"
+            android:onClick="@{() -> view.onClick(btnClose)}"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/cl_main"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_main"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/spacing_normal"
+            app:layout_constraintBottom_toTopOf="@id/btn_application"
+            app:layout_constraintTop_toBottomOf="@id/btn_close"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_image"
+                android:layout_width="300dp"
+                android:layout_height="300dp"
+                android:src="@drawable/ic_image_holder"
+                android:scaleType="centerCrop"
+                android:layout_margin="@dimen/spacing_normal"
+                app:layout_constraintBottom_toTopOf="@id/btn_gallery"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_gallery"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                style="@style/button.fill"
+                android:text="@string/btn_gallery"
+                android:onClick="@{() -> view.onClick(btnGallery)}"
+                app:layout_constraintBottom_toTopOf="@id/et_name"
+                app:layout_constraintTop_toBottomOf="@id/iv_image"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/btn_camera"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_camera"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                style="@style/button.fill"
+                android:text="@string/btn_camera"
+                android:onClick="@{() -> view.onClick(btnCamera)}"
+                app:layout_constraintStart_toEndOf="@id/btn_gallery"
+                app:layout_constraintTop_toTopOf="@id/btn_gallery"
+                app:layout_constraintBottom_toBottomOf="@id/btn_gallery"
+                app:layout_constraintEnd_toEndOf="parent" />
+
+            <EditText
+                android:id="@+id/et_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"
+                android:hint="@string/landmark_name_hint"
+                android:textAppearance="@style/text.h2"
+                android:layout_marginTop="@dimen/spacing_normal"
+                android:layout_marginHorizontal="@dimen/spacing_small"
+                android:padding="@dimen/spacing_small"
+                app:layout_constraintTop_toBottomOf="@id/btn_gallery"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toTopOf="@id/tv_location"/>
+
+            <TextView
+                android:id="@+id/tv_location"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/text.h3"
+                android:text="@{@string/location_format(viewModel.latLng.latitude, viewModel.latLng.longitude)}"
+                android:padding="@dimen/spacing_small"
+                android:layout_margin="@dimen/spacing_small"
+                app:layout_constraintTop_toBottomOf="@id/et_name"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_application"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/btn_application"
+            android:onClick="@{() -> view.onClick(btnApplication)}"
+            style="@style/button.fill"
+            app:layout_constraintTop_toBottomOf="@id/cl_main"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,4 +71,15 @@
     <string name="delete_my_guestbook_content">&quot;%s&quot;</string>
     <string name="delete_my_guestbook_message">이(가) 삭제됩니다.</string>
 
+    <!-- landmark application -->
+    <string name="btn_gallery">갤러리에서 선택하기</string>
+    <string name="btn_camera">사진 촬영하기</string>
+    <string name="landmark_name_hint">랜드마크 이름을 입력해주세요.</string>
+    <string name="location_format">현재위치 위도 : %f, 경도 : %f</string>
+    <string name="btn_application">신청하기</string>
+    <string name="apply_fail_title">랜드마크 신청 실패</string>
+    <string name="apply_fail_message">랜드마크 신청에 실패했습니다.\n잠시 후 다시 시도해주세요.</string>
+    <string name="apply_success_title">랜드마크 신청 성공</string>
+    <string name="apply_success_message">랜드마크 신청에 성공했습니다.\n검토 후 승인까지 1~2일이 소요됩니다.</string>
+
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path
+        name="my_images"
+        path="Android/data/com.pns.albang/files/Pictures" />
+</paths>


### PR DESCRIPTION
## 개요
#61 [epic] : 랜드마크 신청 기능 구현
반영브랜치 : feature/landmark -> develop

## 작업 내용
랜드마크 신청 바텀 시트 view xml 작성
필요 리소스 추가
랜드마크 신청 기능 바텀 시트 다이얼로그로 ui/ux 구성
이미지 로딩 라이브러리 glide 사용
랜드마크 신청 api 로직 구현
저장소 접근 안드로이드 11 대응

resolves #61 
resolves #62 
resolves #63 
